### PR TITLE
Fix for sub _indent if $self->{ '_level' } is undefinded

### DIFF
--- a/lib/pgFormatter/Beautify.pm
+++ b/lib/pgFormatter/Beautify.pm
@@ -1850,7 +1850,7 @@ sub _indent {
     my ( $self ) = @_;
 
     if ( $self->{ '_new_line' } ) {
-        return $self->{ 'space' } x ( $self->{ 'spaces' } * $self->{ '_level' } );
+        return $self->{ 'space' } x ( $self->{ 'spaces' } * ( $self->{ '_level' } // 0 ) );
     }
     else {
         return $self->{ 'space' };


### PR DESCRIPTION
Some times due to wrong original SQL text '_level' may be undef. It is better to have zero (may be wrong) indentation than program die.
I guess than undef may be due to several `$self->{ '_level' } = $self->{ '_level_stack' }[-1];` in the code. If stack is by some reason empty, we will have undef for '_level'.